### PR TITLE
Update to bypass detection as of July 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,17 +65,9 @@ Other versions might work, but have not been tested.
 
 ### Temporary Installation
 
-1. Clone or [download](https://github.com/MartinBraquet/youtube-adblock/archive/main.zip) the repo
+1. Clone or [download](https://github.com/MartinBraquet/youtube-adblock/archive/main.zip) the repo (and extract the zip file)
 
-   ```sh
-   git clone git@github.com:MartinBraquet/youtube-adblock.git
-    ```
-
-2. Type `about:debugging` in the Firefox URL search bar and click on **"This Firefox"**
-
-   ```url
-   about:debugging#/runtime/this-firefox
-   ```
+2. Navigate to `about:debugging#/runtime/this-firefox` in the Firefox URL search bar
 
 3. Right next to **Temporary Extensions** click on **"Load Temporary Add-on…"**
 

--- a/README.md
+++ b/README.md
@@ -63,13 +63,32 @@ Since this playback rate can cause issues or be too little for some users, this 
 
 Other versions might work, but have not been tested.
 
-### Installation
+### Temporary Installation
+
+1. Clone or [download](https://github.com/MartinBraquet/youtube-adblock/archive/main.zip) the repo
+
+   ```sh
+   git clone git@github.com:MartinBraquet/youtube-adblock.git
+    ```
+
+2. Type `about:debugging` in the Firefox URL search bar and click on **"This Firefox"**
+
+   ```url
+   about:debugging#/runtime/this-firefox
+   ```
+
+3. Right next to **Temporary Extensions** click on **"Load Temporary Add-on…"**
+
+4. In the selection click on any file in the root directory of the local extension
+
+### Development Installation
 
 1. Clone the repo
 
    ```sh
    git clone git@github.com:MartinBraquet/youtube-adblock.git
     ```
+
 2. Install the prerequisites
 
    For Debian-based distributions:
@@ -83,6 +102,7 @@ Other versions might work, but have not been tested.
    ```
 
 3. Run the extension
+
    ```sh
    web-ext run
    ```
@@ -94,6 +114,7 @@ Other versions might work, but have not been tested.
    ```sh
    Ctrl + Shift + I
    ```
+
    Or `about:debugging#/runtime/this-firefox` and click on `Inspect` to open the extension console.
 
 ### Build

--- a/_manifest_v3.json
+++ b/_manifest_v3.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "YouTube AdBlock",
   "version": "1.52",
-  "description": "Accelerates and Skips YouTube Ads in Less Than a Second",
+  "description": "Accelerates and Skips YouTube Ads in Two Seconds or Less",
   "permissions": [
     "storage",
     "tabs",

--- a/content.js
+++ b/content.js
@@ -116,7 +116,6 @@ async function checkForAds() {
                                 console.log("YtAd detected, clicking skip button (" + skipButton.className + ")");
                             } else if (skipBehavior == 2) {
                                 skipVideo();
-                                console.log("YtAd detected, skipping to the end");
                             }
                         }
                     }

--- a/content.js
+++ b/content.js
@@ -109,8 +109,7 @@ async function checkForAds() {
                     }
 
                     let boostWanted = await readLocalStorage("boostWanted");
-                    let skipBehavior = await readLocalStorage("skipBehavior");
-                    if (boostWanted && skipBehavior === 2) {
+                    if (boostWanted) {
                         setTimeout(skipVideo, 2000, video);
                     }
                 } else if (video.currentTime === 0 && video.detected) {

--- a/content.js
+++ b/content.js
@@ -76,8 +76,9 @@ async function checkForAds() {
         let _adExist = adExist(player);
         let videos = player.getElementsByClassName("video-stream html5-main-video");
         for (const video of videos) {
+            if (!video) continue;
             if (_adExist) {
-                if (video && !video.paused && !video.detected) {
+                if (!video.paused && !video.detected) {
                     video.detected = true;
                     browser.runtime.sendMessage({ adsSkipped: true });
 
@@ -103,20 +104,22 @@ async function checkForAds() {
                     if (skipBehavior === 2) {
                         setTimeout(skipVideo, 2000);
                     }
+                } else if (video.currentTime == 0 && video.detected) {
+                    video.detected = false;
                 }
 
                 let skipBehavior = await readLocalStorage("skipBehavior");
-                if (skipBehavior > 0) {
-                    let skipButtons = getSkipButtons();
-                    for (const skipButton of skipButtons) {
-                        if (skipButton && !skipButton.clicked && skipButton.style.display !== "none") {
-                            skipButton.clicked = true;
-                            if (skipBehavior === 1) {
-                                skipButton.click();
-                                console.log("YtAd detected, clicking skip button (" + skipButton.className + ")");
-                            } else if (skipBehavior === 2) {
-                                skipVideo();
-                            }
+                let skipButtons = getSkipButtons();
+                for (const skipButton of skipButtons) {
+                    if (skipButton && !skipButton.clicked && skipButton.style.display !== "none") {
+                        skipButton.clicked = true;
+                        if (skipBehavior === 1) {
+                            skipButton.click();
+                            console.log("YtAd detected, clicking skip button (" + skipButton.className + ")");
+                        } else if (skipBehavior === 2) {
+                            skipVideo();
+                        } else {
+                            console.log("YtAd detected, skip button detected but the skip behavior is set to 'do nothing'");
                         }
                     }
                 }

--- a/content.js
+++ b/content.js
@@ -76,7 +76,6 @@ async function checkForAds() {
         let _adExist = adExist(player);
         let videos = player.getElementsByClassName("video-stream html5-main-video");
         for (const video of videos) {
-            let _adDuration = video.duration;
             if (_adExist) {
                 if (video && !video.detected) {
                     video.detected = true;
@@ -109,24 +108,23 @@ async function checkForAds() {
                 let skipButtons = getSkipButtons();
                 for (const skipButton of skipButtons) {
                     if (skipButton && !skipButton.clicked && skipButton.style.display !== "none") {
+                        skipButton.clicked = true;
                         // cannot simulate click on skip button, it will be detected
                         // skipButton.click();
                         skipVideo();
-                        skipButton.clicked = true;
                         console.log("YtAd detected, clicking skip button (" + skipButton.className + ")");
                     }
                 }
 
                 function skipVideo() {
-                    _adExist = adExist(player);
-                    if (video && _adExist && video.duration === _adDuration) {
-                        video.currentTime = _adDuration;
-                        console.log("YtAd detected, boosting to " + video.playbackRate + "x");
+                    if (video && video.detected) {
                         video.detected = false;
+                        video.currentTime = video.duration;
+                        console.log("YtAd detected, skipping to the end.");
                     }
                 }
             } else {
-                if (video.playbackRate > 2 || video.hidden || video.detected) {
+                if (video.detected) {
                     video.muted = userMuted;
                     video.hidden = false;
                     if (document.URL.includes("music.youtube.com")) {

--- a/content.js
+++ b/content.js
@@ -99,8 +99,8 @@ async function checkForAds() {
                         console.log("YtAd detected, accelerating video " + video.playbackRate + "x");
                     }
 
-                    let forceSkip = await readLocalStorage("forceSkip",);
-                    if (forceSkip) {
+                    let skipBehavior = await readLocalStorage("skipBehavior");
+                    if (skipBehavior === 2) {
                         setTimeout(skipVideo, 2000);
                     }
                 }
@@ -111,10 +111,10 @@ async function checkForAds() {
                     for (const skipButton of skipButtons) {
                         if (skipButton && !skipButton.clicked && skipButton.style.display !== "none") {
                             skipButton.clicked = true;
-                            if (skipBehavior == 1) {
+                            if (skipBehavior === 1) {
                                 skipButton.click();
                                 console.log("YtAd detected, clicking skip button (" + skipButton.className + ")");
-                            } else if (skipBehavior == 2) {
+                            } else if (skipBehavior === 2) {
                                 skipVideo();
                             }
                         }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "YouTube AdBlock",
-  "version": "1.69",
+  "version": "1.70",
   "description": "Accelerates and skips YouTube Ads in Two Seconds or Less",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start:firefox-android": "web-ext run -t firefox-android --adb-device R58NC0CSMMH --firefox-apk org.mozilla.fenix --verbose"
   },
   "name": "youtube-adblock",
-  "description": "Accelerates and Skips YouTube Ads in Less Than a Second",
+  "description": "Accelerates and Skips YouTube Ads in Two Seconds or Less",
   "main": "background.js",
   "keywords": [],
   "license": "ISC",

--- a/popup.html
+++ b/popup.html
@@ -127,11 +127,11 @@
   <p>Ads Blocked: <span id="adsSkipped"></span></p>
   <table>
     <tr>
-      <td align="left"><label for="adPlaybackRate">Playback Rate:</label></td>
+      <td align="left"><label for="adPlaybackRate">Playback Rate</label></td>
       <td><input type="number" id="adPlaybackRate" name="adPlaybackRate" min="1" max="1000" size="5"></td>
     </tr>
     <tr>
-      <td align="left"><label for="muteWanted">Mute Ad:</label></td>
+      <td align="left"><label for="muteWanted">Mute Ad</label></td>
       <td>
         <label class="switch">
           <input type="checkbox" id="muteWanted" name="muteWanted">
@@ -140,7 +140,7 @@
       </td>
     </tr>
     <tr>
-      <td align="left"><label for="hideWanted">Hide Ad:</label></td>
+      <td align="left"><label for="hideWanted">Hide Ad</label></td>
       <td>
         <label class="switch">
           <input type="checkbox" id="hideWanted" name="hideWanted">
@@ -149,7 +149,7 @@
       </td>
     </tr>
     <tr>
-      <td align="left"><label for="boostWanted">Boost after 2s:</label></td>
+      <td align="left"><label for="boostWanted">Boost After 2s</label></td>
       <td>
         <label class="switch">
           <input type="checkbox" id="boostWanted" name="boostWanted">
@@ -158,12 +158,12 @@
       </td>
     </tr>
     <tr>
-      <td align="left"><label for="skipBehavior">If Skip Available:</label></td>
+      <td align="left"><label for="skipBehavior">If Skip Available</label></td>
       <td>
         <select id="skipBehavior" name="skipBehavior">
           <option value=0>Do Nothing</option>
           <option value=1>Click Button</option>
-          <option value=2>Go to Ad End</option>
+          <option value=2>Boost Ad</option>
       </td>
     </tr>
   </table>

--- a/popup.html
+++ b/popup.html
@@ -150,15 +150,6 @@
       </td>
     </tr>
     <tr>
-      <td align="left"><label for="forceSkip">Force Skip After 2s:</label></td>
-      <td>
-        <label class="switch">
-          <input type="checkbox" id="forceSkip" name="forceSkip">
-          <span class="slider round"></span>
-        </label>
-      </td>
-    </tr>
-    <tr>
       <td align="left"><label for="skipBehavior">If Skip Available:</label></td>
       <td>
         <select id="skipBehavior" name="skipBehavior">

--- a/popup.html
+++ b/popup.html
@@ -149,12 +149,21 @@
       </td>
     </tr>
     <tr>
+      <td align="left"><label for="boostWanted">Boost after 2s:</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="boostWanted" name="boostWanted">
+          <span class="slider round"></span>
+        </label>
+      </td>
+    </tr>
+    <tr>
       <td align="left"><label for="skipBehavior">If Skip Available:</label></td>
       <td>
         <select id="skipBehavior" name="skipBehavior">
           <option value=0>Do Nothing</option>
           <option value=1>Click Button</option>
-          <option value=2>Force Skip</option>
+          <option value=2>Go to Ad End</option>
       </td>
     </tr>
   </table>

--- a/popup.html
+++ b/popup.html
@@ -149,6 +149,15 @@
       </td>
     </tr>
     <tr>
+      <td align="left"><label for="boostWanted">Boost after 2s:</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="boostWanted" name="boostWanted">
+          <span class="slider round"></span>
+        </label>
+      </td>
+    </tr>
+    <tr>
       <td align="left"><label for="skipBehavior">If Skip Available:</label></td>
       <td>
         <select id="skipBehavior" name="skipBehavior">

--- a/popup.html
+++ b/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+
 <head>
   <title>YouTube AdBlock</title>
   <style>
@@ -13,13 +14,31 @@
       color: #F0FFFF;
       border-radius: 30px;
     }
+
     small {
       font-size: 10px;
     }
+
     h1 {
       color: #F0FFFF;
       font-size: 24px;
     }
+
+    .banner {
+      margin-top: 20px;
+      padding: 10px;
+      border-radius: 15px;
+    }
+
+    .banner img {
+      height: 50px;
+      border-radius: 10px;
+    }
+
+    p.status {
+      color: #4CAF50;
+    }
+
     .button {
       display: inline-block;
       padding: 10px 20px;
@@ -30,58 +49,129 @@
       text-decoration: none;
       outline: none;
       color: #fff;
-      background-color: #0088cc;
       border: none;
       border-radius: 10px;
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
       transition: all 0.3s;
     }
 
-    .button:hover {
+    .button,
+    input:checked+.slider {
+      background-color: #0088cc;
+    }
+
+    .button:hover,
+    input:checked+.slider:hover {
       background-color: #005c99;
     }
-    .button:active {
-      background-color: #005c99;
-      box-shadow: 0 5px #666;
-      transform: translateY(4px);
+
+    .button:active,
+    input+.slider:active {
+      box-shadow: 0 3px #666;
+      transform: translateY(2px);
     }
-    .banner {
-      margin-top: 20px;
-      padding: 10px;
-      border-radius: 15px;
+
+    .switch {
+      position: relative;
+      display: inline-block;
+      width: 45px;
+      height: 24px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
-    .banner img {
-      height: 50px;
-      border-radius: 10px;
+
+    .switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
     }
-    p.status {
-      color: #4CAF50;
+
+    .slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #ccc;
+      border-radius: 24px;
+      -webkit-transition: .1s;
+      transition: .1s;
+    }
+
+    .slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 4px;
+      bottom: 3px;
+      background-color: white;
+      border-radius: 50%;
+      -webkit-transition: .1s;
+      transition: .1s;
+    }
+
+    input:hover+.slider {
+      background-color: #aaa;
+    }
+
+    input:checked+.slider:before {
+      -webkit-transform: translateX(20px);
+      -ms-transform: translateX(20px);
+      transform: translateX(20px);
     }
   </style>
 </head>
+
 <body>
   <h1>YouTube<br>AdBlock</h1>
   <p>Ads Blocked: <span id="adsSkipped"></span></p>
   <table>
     <tr>
-      <td align="left"><label for="adPlaybackRate">Playback rate:</label></td>
+      <td align="left"><label for="adPlaybackRate">Playback Rate:</label></td>
       <td><input type="number" id="adPlaybackRate" name="adPlaybackRate" min="1" max="1000" size="5"></td>
     </tr>
     <tr>
-      <td align="left"><label for="skipWanted">Force Skip after 2s:</label></td>
-      <td><input type="checkbox" id="skipWanted" name="skipWanted"></td>
+      <td align="left"><label for="muteWanted">Mute Ad:</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="muteWanted" name="muteWanted">
+          <span class="slider round"></span>
+        </label>
+      </td>
     </tr>
     <tr>
-      <td align="left"><label for="muteWanted">Mute ad:</label></td>
-      <td><input type="checkbox" id="muteWanted" name="muteWanted"></td>
+      <td align="left"><label for="hideWanted">Hide Ad:</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="hideWanted" name="hideWanted">
+          <span class="slider round"></span>
+        </label>
+      </td>
     </tr>
     <tr>
-      <td align="left"><label for="hideWanted">Hide ad:</label></td>
-      <td><input type="checkbox" id="hideWanted" name="hideWanted"></td>
+      <td align="left"><label for="forceSkip">Force Skip After 2s:</label></td>
+      <td>
+        <label class="switch">
+          <input type="checkbox" id="forceSkip" name="forceSkip">
+          <span class="slider round"></span>
+        </label>
+      </td>
+    </tr>
+    <tr>
+      <td align="left"><label for="skipBehavior">If Skip Available:</label></td>
+      <td>
+        <select id="skipBehavior" name="skipBehavior">
+          <option value=0>Do Nothing</option>
+          <option value=1>Click Button</option>
+          <option value=2>Force Skip</option>
+      </td>
     </tr>
   </table>
+  <button class="button" id="restoreDefaults">Restore Defaults</button>
   <p><small>Note: the higher the playback rate,<br>the more likely YouTube will notice.</small></p>
   <script src="utils.js"></script>
   <script src="popup.js"></script>
 </body>
+
 </html>

--- a/popup.html
+++ b/popup.html
@@ -62,9 +62,24 @@
 <body>
   <h1>YouTube<br>AdBlock</h1>
   <p>Ads Blocked: <span id="adsSkipped"></span></p>
-  <p><label for="adPlaybackRate">Playback rate:</label><input type="number" id="adPlaybackRate" name="adPlaybackRate" min="3" max="1000" size="5"></p>
-<!--  <p><label for="boostWanted">Boost after 2s:</label><input type="checkbox" id="boostWanted" name="boostWanted"></p>-->
-  <p><label for="muteWanted">Mute ad:</label><input type="checkbox" id="muteWanted" name="muteWanted"></p>
+  <table>
+    <tr>
+      <td align="left"><label for="adPlaybackRate">Playback rate:</label></td>
+      <td><input type="number" id="adPlaybackRate" name="adPlaybackRate" min="1" max="1000" size="5"></td>
+    </tr>
+    <tr>
+      <td align="left"><label for="skipWanted">Force Skip after 2s:</label></td>
+      <td><input type="checkbox" id="skipWanted" name="skipWanted"></td>
+    </tr>
+    <tr>
+      <td align="left"><label for="muteWanted">Mute ad:</label></td>
+      <td><input type="checkbox" id="muteWanted" name="muteWanted"></td>
+    </tr>
+    <tr>
+      <td align="left"><label for="hideWanted">Hide ad:</label></td>
+      <td><input type="checkbox" id="hideWanted" name="hideWanted"></td>
+    </tr>
+  </table>
   <p><small>Note: the higher the playback rate,<br>the more likely YouTube will notice.</small></p>
   <script src="utils.js"></script>
   <script src="popup.js"></script>

--- a/popup.html
+++ b/popup.html
@@ -42,7 +42,7 @@
     .button {
       display: inline-block;
       padding: 10px 20px;
-      margin: 10px;
+      margin-top: 10px;
       font-size: 14px;
       cursor: pointer;
       text-align: center;
@@ -65,8 +65,7 @@
       background-color: #005c99;
     }
 
-    .button:active,
-    input+.slider:active {
+    .button:active {
       box-shadow: 0 3px #666;
       transform: translateY(2px);
     }

--- a/popup.js
+++ b/popup.js
@@ -14,16 +14,20 @@ function setElement(x, value) {
     });
 }
 
-function addListener(x, value) {
+function addListener(x, value, conversion) {
     let element = document.getElementById(x);
     element.addEventListener('change', (event) => {
-        local.set({[x]: event.target[value]});
+        let v = event.target[value];
+        if (conversion === "int") {
+            v = parseInt(v);
+        }
+        local.set({[x]: v});
     });
 }
 
-function setElementAndListener(x, value) {
+function setElementAndListener(x, value, conversion) {
     setElement(x, value);
-    addListener(x, value);
+    addListener(x, value, conversion);
 }
 
 function restoreDefaults() {
@@ -43,6 +47,6 @@ document.addEventListener('DOMContentLoaded', function () {
     setElementAndListener("adPlaybackRate", "value");
     setElementAndListener("muteWanted", "checked");
     setElementAndListener("hideWanted", "checked");
-    setElementAndListener("skipBehavior", "value");
+    setElementAndListener("skipBehavior", "value", "int");
     document.getElementById("restoreDefaults").addEventListener('click', restoreDefaults);
 });

--- a/popup.js
+++ b/popup.js
@@ -26,10 +26,24 @@ function setElementAndListener(x, value) {
     addListener(x, value);
 }
 
+function restoreDefaults() {
+    for (let x in defaultOptions) {
+        local.set({[x]: defaultOptions[x]});
+        let element = document.getElementById(x);
+        if (typeof defaultOptions[x] === "boolean") {
+            element.checked = defaultOptions[x];
+        } else {
+            element.value = defaultOptions[x];
+        }
+    }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     setElement("adsSkipped", "textContent");
     setElementAndListener("adPlaybackRate", "value");
     setElementAndListener("muteWanted", "checked");
-    setElementAndListener("skipWanted", "checked");
+    setElementAndListener("forceSkip", "checked");
     setElementAndListener("hideWanted", "checked");
+    setElementAndListener("skipBehavior", "value");
+    document.getElementById("restoreDefaults").addEventListener('click', restoreDefaults);
 });

--- a/popup.js
+++ b/popup.js
@@ -30,5 +30,6 @@ document.addEventListener('DOMContentLoaded', function () {
     setElement("adsSkipped", "textContent");
     setElementAndListener("adPlaybackRate", "value");
     setElementAndListener("muteWanted", "checked");
-    // setElementAndListener("boostWanted", "checked");
+    setElementAndListener("skipWanted", "checked");
+    setElementAndListener("hideWanted", "checked");
 });

--- a/popup.js
+++ b/popup.js
@@ -14,16 +14,20 @@ function setElement(x, value) {
     });
 }
 
-function addListener(x, value) {
+function addListener(x, value, conversion) {
     let element = document.getElementById(x);
     element.addEventListener('change', (event) => {
-        local.set({[x]: event.target[value]});
+        let v = event.target[value];
+        if (conversion === "int") {
+            v = parseInt(v);
+        }
+        local.set({[x]: v});
     });
 }
 
-function setElementAndListener(x, value) {
+function setElementAndListener(x, value, conversion) {
     setElement(x, value);
-    addListener(x, value);
+    addListener(x, value, conversion);
 }
 
 function restoreDefaults() {
@@ -43,6 +47,7 @@ document.addEventListener('DOMContentLoaded', function () {
     setElementAndListener("adPlaybackRate", "value");
     setElementAndListener("muteWanted", "checked");
     setElementAndListener("hideWanted", "checked");
-    setElementAndListener("skipBehavior", "value");
+    setElementAndListener("boostWanted", "checked");
+    setElementAndListener("skipBehavior", "value", "int");
     document.getElementById("restoreDefaults").addEventListener('click', restoreDefaults);
 });

--- a/popup.js
+++ b/popup.js
@@ -42,7 +42,6 @@ document.addEventListener('DOMContentLoaded', function () {
     setElement("adsSkipped", "textContent");
     setElementAndListener("adPlaybackRate", "value");
     setElementAndListener("muteWanted", "checked");
-    setElementAndListener("forceSkip", "checked");
     setElementAndListener("hideWanted", "checked");
     setElementAndListener("skipBehavior", "value");
     document.getElementById("restoreDefaults").addEventListener('click', restoreDefaults);

--- a/utils.js
+++ b/utils.js
@@ -1,7 +1,8 @@
 const defaultOptions = {
     adsSkipped: 0,
-    adPlaybackRate: 12,
-    boostWanted: false,
-    muteWanted: true
+    adPlaybackRate: 5,
+    skipWanted: false,
+    muteWanted: true,
+    hideWanted: true
 }
 let local = browser.storage.local;

--- a/utils.js
+++ b/utils.js
@@ -1,8 +1,9 @@
 const defaultOptions = {
     adsSkipped: 0,
     adPlaybackRate: 5,
-    skipWanted: false,
     muteWanted: true,
-    hideWanted: true
+    hideWanted: true,
+    forceSkip: false,
+    skipBehavior: 2
 }
 let local = browser.storage.local;

--- a/utils.js
+++ b/utils.js
@@ -3,6 +3,7 @@ const defaultOptions = {
     adPlaybackRate: 5,
     muteWanted: true,
     hideWanted: true,
+    boostWanted: false,
     skipBehavior: 2
 }
 let local = browser.storage.local;

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,6 @@ const defaultOptions = {
     adPlaybackRate: 5,
     muteWanted: true,
     hideWanted: true,
-    forceSkip: false,
     skipBehavior: 2
 }
 let local = browser.storage.local;


### PR DESCRIPTION
## Notes
Apparently you cannot simulate clicks on the skip button anymore.
I tired and at least for now we can skip the video manually by changing the `video.currentTime`.
This however results in the player showing the download button for specific ads with install links.
![grafik](https://github.com/MartinBraquet/youtube-adblock/assets/65172029/02b341e2-35c4-45e9-8425-3b964c97dfec)
Notice the piechart timer in the top right corner. This ad goes away automatically by Youtube itself after 5 seconds.
Also I neatly ordered the popup inputs into a table.

## Changes
* Added option to toggle ad visibility (hide by default)
* Added option to force skip ad after 2s (off by default)
* Temporarily disabled `SkipButton.click()` because it gets detected